### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The simplest way to deploy and test your add-in is to copy the files to a networ
     
 ### Test add-in in Word
 
-    a.  In the **Insert tab** in Excel 2016, choose **My Add-ins**. 
+    a.  In the **Insert tab** in Word 2016, choose **My Add-ins**. 
     
     b.  In the **Office Add-ins** dialog box, choose **Shared Folder**.
     


### PR DESCRIPTION
The documentation was referring to Excel 2016 instead of Word 2016 that was the target of this sample.